### PR TITLE
Modif de l'ecart aentre les deux carte ha et haoff

### DIFF
--- a/layouts/partials/sections/landing_double.html
+++ b/layouts/partials/sections/landing_double.html
@@ -1,7 +1,7 @@
 <section class="py-5 bg-light">
   <div class="container text-center">
-    <div class="row row-cols-1 row-cols-md-2 justify-content-evenly">
-      <div class="col">
+    <div class="row justify-content-center">
+      <div class="col-11 col-lg-5">
         <div class="card h-100 border border-opacity-50 border-3 border-secondary rounded pt-3 text-center mx-auto" style="max-width: 30rem;">
           <img
             class="card-img-top mx-auto"
@@ -51,7 +51,7 @@
       </div>
 
 
-      <div class="col">
+      <div class="col-11 col-lg-5">
         <div class="card h-100 border border-opacity-50 border-3 border-secondary rounded pt-3 text-center mx-auto" style="max-width: 30rem;">
           <img
             class="card-img-top mx-auto"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,7 +1351,7 @@
   "dependencies": {
     "@fullhuman/postcss-purgecss": {
       "version": "git+ssh://git@github.com/fullhuman/postcss-purgecss.git#9fdc940aff30a108d6d4fe1c5f6b2635bf6b3b27",
-      "from": "@fullhuman/postcss-purgecss@github:fullhuman/postcss-purgecss",
+      "from": "@fullhuman/postcss-purgecss@fullhuman/postcss-purgecss",
       "requires": {
         "postcss": "^7.0.14",
         "purgecss": "^1.4.0"


### PR DESCRIPTION
Modif liée" au Mail 25 novembre 2022 18:00:15 GMT+01:00

3.       Dans l'accueil, les 2 blocs ont trop d’espaces entre eux, sont trop étroits et devraient être collés.