### PR TITLE
Add title metadata to 'Articles' and 'Actualités'

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,4 +1,5 @@
 ---
 type: post
 visibleInCMS: false
+title: Articles
 ---

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -1,4 +1,5 @@
 ---
 type: news
 visibleInCMS: false
+title: Actualités
 ---


### PR DESCRIPTION
Si les pages de chaque article ont bien le nom de l'article dans la barre de titre du navigateur, ça n'est pas le cas de la liste des articles ou la page des actualités.
à la place, on n'a que le nom du navigateur qui est affiché.
La solution que j'ai trouvé est de rajouter la metadonnée `title` à fin de nomer la page comme elle est affichée dans le menu.
Peut-être y a-t-il une autre donnée qui pourrait être utilisée à la place ?
Je n'ai pas trouvé, cela dit ça voudrait dire de multiple conditions dans la balise title, pas sûr que ça serait plus propre.
