### PR TITLE
Add fast navigation link to jump to page content

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 {{ define "main"}}
-    <main id="main">
+    <main id="content">
       <div>
         <h1 style="text-align: center">La page n'existe pas</h1>
         <h2 style="text-align: center">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,9 +6,9 @@
 
 
 
-        <main id="content">
+        {{ if eq .Kind "404" }}{{ else }}<main id="content"> {{ end }}
         {{- block "main" . }}{{- end }}
-        </main>
+        {{ if eq .Kind "404" }}{{ else }}</main>{{ end }}
 
 
     

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,9 @@
 
 
 
+        <main id="content"></main>
         {{- block "main" . }}{{- end }}
+        </main>
 
 
     

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
 
 
 
-        <main id="content"></main>
+        <main id="content">
         {{- block "main" . }}{{- end }}
         </main>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,4 @@
+<a href="#content" class="sr-only sr-only-focusable">Aller au contenu</a>
 <header class="sticky-top">
 {{ partial "menus/main" . }}
 </header>


### PR DESCRIPTION
Ajout d'un lien visible uniquement par les lecteurs d'écran permettant de sauter directement au contenu.
Comme je l'ai précisé dans l'issue consacrée, ça n'est pas satisfaisant, même si on est à 99% vu que j'avais ma balise main fermée dès l'ouverture à cause d'une auto-complétion pas corrigée.
Il faut que je vois à tout couvrir en faisant comme tu me l'avais dit @McFlyPartages à moins que je face une condition pour ne pas ouvrir et fermer ma balise si on est dans la page 404.
Fixes #534 